### PR TITLE
Fix: stopped regenerating `.env` file on every install (i.e. executing `./install.sh`)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-cp sample.env .env
+# We'll check if .env file exists already or not.
+FILE=./.env
+if !(test -f "$FILE"); then
+    echo "$FILE doesn't exists. Copying from <sample.env> to <.env>"
+    cp sample.env .env
+fi
 
 # Starting all the services together is leading to some issues with fusion auth
 # Fusion auth is not able to acquire the lock and a restart is required for the system


### PR DESCRIPTION
If someone hit `./install.sh` knowingly/unknowingly to apply new changes post-UPing docker previously, the `.env` file was getting overwritten by `sample.env`.

This MR is to ignore the re-generating of the `.env` file upon later installations.